### PR TITLE
fix : correct the duration of icpc 2024 domestic

### DIFF
--- a/public/standings_2024_domestic.json
+++ b/public/standings_2024_domestic.json
@@ -2,7 +2,7 @@
     "ContestData": {
         "UnitTime": "second",
         "Penalty": 1200,
-        "Duration": 18000,
+        "Duration": 10800,
         "TaskInfo": [
             "A",
             "B",


### PR DESCRIPTION
Correct the duration of the 2024 Domestic from 18000 to 10800

## 修正した箇所

2024国内のコンテスト期間の秒数のみ

## スクショ

←修正前，修正後→
<img width="400" alt="修正前(18000sec)" src="https://github.com/shogo314/icpc-replay/assets/65126083/6b5b8566-4801-4639-aa9f-1aff9cf24e60"><img width="400" alt="修正後(10800sec)" src="https://github.com/shogo314/icpc-replay/assets/65126083/a9b2ed6b-fc26-4a3c-8138-a436a193158c">
